### PR TITLE
The error_message is not always set

### DIFF
--- a/Services/GeocodeService.php
+++ b/Services/GeocodeService.php
@@ -84,7 +84,7 @@ class GeocodeService
 
     public function handleError($response)
     {
-        if ($response->error_message) {
+        if (isset($response->error_message)) {
             $msg = $response->error_message;
         } else {
             $msg = 'There has been an error while communicating with Google API';


### PR DESCRIPTION
response from Google Api does not always contain error_message. Added check if the message isset.
