### PR TITLE
Making service definition compliant with SF3

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,11 +2,11 @@
 services:
   happyr.google.geocoder.geocode:
     class: HappyR\Google\GeocoderBundle\Services\GeocodeService
-    arguments: [@happyr.google.geocoder.scraper, %happy_r_google_geocoder%]
+    arguments: ["@happyr.google.geocoder.scraper", %happy_r_google_geocoder%]
 
   happyr.google.geocoder.places.autocomplete:
     class: HappyR\Google\GeocoderBundle\Services\PlacesAutocompleteService
-    arguments: [@happyr.google.geocoder.scraper, %happy_r_google_geocoder%]
+    arguments: ["@happyr.google.geocoder.scraper", %happy_r_google_geocoder%]
 
   happyr.google.geocoder.scraper:
     class: HappyR\Google\GeocoderBundle\Services\ScraperService


### PR DESCRIPTION
The new SF3 requires that service references should be quoted
